### PR TITLE
Cant access any uuids you didnt originally 'filter' for

### DIFF
--- a/lib/webbluetooth/bindings.js
+++ b/lib/webbluetooth/bindings.js
@@ -6,6 +6,10 @@ var debug = require('debug')('bindings');
 var ble = navigator.bluetooth;
 
 
+function makeList(uuid){
+  return {services:[ uuid ]};
+}
+
 function addDashes(uuid){
   if(!uuid){
     return uuid;
@@ -65,7 +69,13 @@ NobleBindings.prototype.startScanning = function(serviceUuids, allowDuplicates) 
     serviceUuids = [serviceUuids];
   }
 
-  ble.requestDevice({ filters: [{ services: serviceUuids.map(addDashes) }] })
+  var dashedUuids = serviceUuids.map(addDashes);
+
+  var serviceList = dashedUuids.map(makeList);
+
+  var request = {filters: serviceList};
+
+  ble.requestDevice(request)
     .then(function(device){
       debug('scan finished', device);
       if(device){

--- a/lib/webbluetooth/bindings.js
+++ b/lib/webbluetooth/bindings.js
@@ -153,7 +153,7 @@ NobleBindings.prototype.discoverServices = function(deviceUuid, uuids) {
 
   //TODO: need web api completed for this to work
   if(peripheral){
-    this.emit('servicesDiscover', deviceUuid, peripheral.device.uuids);
+    this.emit('servicesDiscover', deviceUuid, peripheral.serviceUuids);
   }
 
 };


### PR DESCRIPTION
Getting:
`DOMException: Origin is not allowed to access the service. Tip: Add the service UUID to 'optionalServices' in requestDevice() options. https://goo.gl/HxfxSQ`

Instead of the recommended solution, Ive found it best to simply require users to request all uuids they want to interact with, and then we put each of those in their own services filter.

https://webbluetoothcg.github.io/web-bluetooth/#example-filter-by-services
